### PR TITLE
feat/play with int shortcuts

### DIFF
--- a/src/main/java/sebastien/perpignane/cardgame/game/contree/ContreeGame.java
+++ b/src/main/java/sebastien/perpignane/cardgame/game/contree/ContreeGame.java
@@ -44,7 +44,7 @@ public class ContreeGame extends AbstractGame<ContreePlayer> {
         }
         JoinGameResult joinGameResult = gamePlayers.joinGame(p);
         p.setGame(this);
-        joinGameResult.replacedPlayer().ifPresent(contreePlayer -> p.receiveHand(contreePlayer.getHand()));
+        joinGameResult.replacedPlayer().ifPresent(replacedPlayer -> p.receiveHand(replacedPlayer.getHand()));
         gameEventSender.sendJoinedGameEvent(this, joinGameResult.playerIndex(), p);
         if (isStarted()) {
 

--- a/src/main/java/sebastien/perpignane/cardgame/game/contree/ContreeGameBuilder.java
+++ b/src/main/java/sebastien/perpignane/cardgame/game/contree/ContreeGameBuilder.java
@@ -2,9 +2,9 @@ package sebastien.perpignane.cardgame.game.contree;
 
 import sebastien.perpignane.cardgame.card.CardDealer;
 
-public class ContreeGameFactory {
+public class ContreeGameBuilder {
 
-    private ContreeGameFactory() {
+    private ContreeGameBuilder() {
     }
 
     public static ContreeGame createGame(ContreeGameConfig gameConfig) {

--- a/src/main/java/sebastien/perpignane/cardgame/game/contree/ContreeGameMain.java
+++ b/src/main/java/sebastien/perpignane/cardgame/game/contree/ContreeGameMain.java
@@ -55,7 +55,7 @@ public class ContreeGameMain {
 
             out.printf("Game will start. Max score is %d%n", maxScore);
 
-            game = ContreeGameFactory.createGame(cliContreeGameConfig);
+            game = ContreeGameBuilder.createGame(cliContreeGameConfig);
 
             game.registerAsGameObserver(GameTextDisplayer.getInstance());
 

--- a/src/test/java/sebastien/perpignane/cardgame/game/contree/ContreeGameIT.java
+++ b/src/test/java/sebastien/perpignane/cardgame/game/contree/ContreeGameIT.java
@@ -25,7 +25,7 @@ class ContreeGameIT {
     @Test
     @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
     void testRunGameWithBotsPlayingRandomCards() throws InterruptedException {
-        ContreeGame game = ContreeGameFactory.createGame(new ContreeGameConfig() { });
+        ContreeGame game = ContreeGameBuilder.createGame(new ContreeGameConfig() { });
         game.registerAsGameObserver(GameTextDisplayer.getInstance());
         ContreePlayer player1 = new ContreePlayerImpl("Player 1", new BiddingBotEventHandler());
 

--- a/src/test/java/sebastien/perpignane/cardgame/game/contree/MockDealBuilder.java
+++ b/src/test/java/sebastien/perpignane/cardgame/game/contree/MockDealBuilder.java
@@ -18,14 +18,13 @@ import static org.mockito.Mockito.when;
  *  * methods returning objects default to null
  *  * methods returning collection default to empty collection
  */
-public class MockDealBuilder {
+class MockDealBuilder {
     private final ContreeDeal deal;
     private final ContreeTrick lastTrick;
 
     private MockDealBuilder() {
         deal = mock(ContreeDeal.class);
         lastTrick = mock(ContreeTrick.class);
-
     }
 
     static MockDealBuilder builder() {


### PR DESCRIPTION
When playing in console, instead of typing bid values, bid suites and card names, you can now use a integer shortcut.
Example:

Select a card among the allowed ones : Q♣ (1), K♣ (2), A♣ (3):

If you type "2", you'll play the K♣ card.